### PR TITLE
Invert merge order in common so it feels more natural

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -152,7 +152,7 @@ const modernConfig = {
 // Common module exports
 // noinspection WebpackConfigHighlighting
 module.exports = {
-    'modernConfig': merge.strategy({
+    'legacyConfig': merge.strategy({
         module: 'prepend',
         plugins: 'prepend',
     })(

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -152,12 +152,18 @@ const modernConfig = {
 // Common module exports
 // noinspection WebpackConfigHighlighting
 module.exports = {
-    'legacyConfig': merge(
+    'modernConfig': merge.strategy({
+        module: 'prepend',
+        plugins: 'prepend',
+    })(
+        baseConfig,
         legacyConfig,
-        baseConfig,
     ),
-    'modernConfig': merge(
-        modernConfig,
+    'modernConfig': merge.strategy({
+        module: 'prepend',
+        plugins: 'prepend',
+    })(
         baseConfig,
+        modernConfig,
     ),
 };


### PR DESCRIPTION
Also fixes the issue where a bundle-specific configuration defined as a string would get overwritten by same-key ones fromm baseConfig (e.g. entries).

I tapped into `done` hook and confirmed configuration does not change after these changes. Still, a 2nd check wouldn't hurt ;)