### PR TITLE
Moved the webpack-cleaner from legacy to modern

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -344,9 +344,6 @@ module.exports = [
                 ],
             },
             plugins: [
-                new CleanWebpackPlugin(
-                    configureCleanWebpack()
-                ),
                 new MiniCssExtractPlugin({
                     path: path.resolve(__dirname, settings.paths.dist.base),
                     filename: path.join('./css', '[name].[chunkhash].css'),
@@ -397,6 +394,9 @@ module.exports = [
                 ],
             },
             plugins: [
+                new CleanWebpackPlugin(
+                    configureCleanWebpack()
+                ),
                 new webpack.optimize.ModuleConcatenationPlugin(),
                 new webpack.BannerPlugin(
                     configureBanner()


### PR DESCRIPTION
For some reason the modern setup is being run first, so the cleaner would remove all files associated with the modern config.